### PR TITLE
Imports librosa.display

### DIFF
--- a/audfprint_match.py
+++ b/audfprint_match.py
@@ -13,6 +13,7 @@ import time
 import psutil
 import matplotlib.pyplot as plt
 import librosa
+import librosa.display
 import numpy as np
 import scipy.signal
 


### PR DESCRIPTION
When running the program with -I parameter I was receiving the following error:

`$ python audfprint.py match -I --dbase fpdbase.pklz audio.wav`
```
Mon Jun 11 19:48:49 2018 Reading hash table fpdbase.pklz
Read fprints for 6 files ( 2882 hashes) from fpdbase.pklz (0.00% dropped)
Mon Jun 11 19:48:52 2018 Analyzed #0 audio.wav of 29.861 s to 849 hashes
Traceback (most recent call last):
  File "audfprint.py", line 490, in <module>
    main(sys.argv)
  File "audfprint.py", line 473, in main
    strip_prefix=args['--wavdir'])
  File "audfprint.py", line 156, in do_cmd
    msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
  File "/audfprint/audfprint_match.py", line 411, in file_match_to_msgs
    self.illustrate_match(analyzer, ht, qry)
  File "/audfprint/audfprint_match.py", line 434, in illustrate_match
    librosa.display.specshow(sgram, sr=sr, hop_length=analyzer.n_hop,
AttributeError: 'module' object has no attribute 'display'
```

I found at [librosa repo](https://github.com/librosa/librosa/issues/441#issuecomment-261044770) that this could be solved by importing `librosa.display` explicitly. 

Now it seems to be working fine.