### PR TITLE
JSON objects returns and DBASE operations displays in deeper detail.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,9 @@ docs/_build/
 fpstats
 fpmstats
 tmp.fpdb
+
+# Dev Stuff
 venv/
+tests/
+precomppkdir/
+queries/

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 fpstats
 fpmstats
 tmp.fpdb
+venv/

--- a/Makefile
+++ b/Makefile
@@ -13,70 +13,70 @@ test: test_onecore test_onecore_precomp test_onecore_newmerge test_onecore_preco
 	rm -f fpdbase*.pklz
 
 test_onecore: fpdbase.pklz
-	${AUDFPRINT} match --dbase fpdbase.pklz query.mp3
+	${AUDFPRINT} match --dbase fpdbase.pklz tests/data/query.mp3
 
 test_remove: fpdbase.pklz
-	${AUDFPRINT} remove --dbase fpdbase.pklz Nine_Lives/05-Full_Circle.mp3 Nine_Lives/01-Nine_Lives.mp3
+	${AUDFPRINT} remove --dbase fpdbase.pklz tests/data/Nine_Lives/05-Full_Circle.mp3 tests/data/Nine_Lives/01-Nine_Lives.mp3
 	${AUDFPRINT} list --dbase fpdbase.pklz
-	${AUDFPRINT} add --dbase fpdbase.pklz Nine_Lives/01-Nine_Lives.mp3 Nine_Lives/05-Full_Circle.mp3
+	${AUDFPRINT} add --dbase fpdbase.pklz tests/data/Nine_Lives/01-Nine_Lives.mp3 tests/data/Nine_Lives/05-Full_Circle.mp3
 	${AUDFPRINT} list --dbase fpdbase.pklz
-	${AUDFPRINT} match --dbase fpdbase.pklz query.mp3
+	${AUDFPRINT} match --dbase fpdbase.pklz tests/data/query.mp3
 
 fpdbase.pklz: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
-	${AUDFPRINT} new --dbase fpdbase.pklz Nine_Lives/0*.mp3
-	${AUDFPRINT} add --dbase fpdbase.pklz Nine_Lives/1*.mp3
+	${AUDFPRINT} new --dbase fpdbase.pklz tests/data/Nine_Lives/0*.mp3
+	${AUDFPRINT} add --dbase fpdbase.pklz tests/data/Nine_Lives/1*.mp3
 
 test_onecore_precomp: precompdir
-	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/Nine_Lives/0*
-	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/Nine_Lives/1*
+	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/tests/data/Nine_Lives/0*
+	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/tests/data/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase1.pklz fpdbase0.pklz
-	${AUDFPRINT} match --dbase fpdbase1.pklz precompdir/query.afpt
+	${AUDFPRINT} match --dbase fpdbase1.pklz precompdir/tests/data/query.afpt
 
 test_onecore_newmerge: precompdir
-	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/Nine_Lives/0*
-	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/Nine_Lives/1*
+	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/tests/data/Nine_Lives/0*
+	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/tests/data/Nine_Lives/1*
 	rm -f fpdbase2.pklz
 	${AUDFPRINT} newmerge --dbase fpdbase2.pklz fpdbase0.pklz fpdbase1.pklz
-	${AUDFPRINT} match --dbase fpdbase2.pklz precompdir/query.afpt
+	${AUDFPRINT} match --dbase fpdbase2.pklz precompdir/tests/data/query.afpt
 
 precompdir: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
 	rm -rf precompdir
 	mkdir precompdir
-	${AUDFPRINT} precompute --precompdir precompdir Nine_Lives/*.mp3
-	${AUDFPRINT} precompute --precompdir precompdir --shifts 4 query.mp3
+	${AUDFPRINT} precompute --precompdir precompdir tests/data/Nine_Lives/*.mp3
+	${AUDFPRINT} precompute --precompdir precompdir --shifts 4 tests/data/query.mp3
 
 test_onecore_precomppk: precomppkdir
-	${AUDFPRINT} new --dbase fpdbase0.pklz precomppkdir/Nine_Lives/0*
-	${AUDFPRINT} new --dbase fpdbase1.pklz precomppkdir/Nine_Lives/1*
+	${AUDFPRINT} new --dbase fpdbase0.pklz precomppkdir/tests/data/Nine_Lives/0*
+	${AUDFPRINT} new --dbase fpdbase1.pklz precomppkdir/tests/data/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase1.pklz fpdbase0.pklz
-	${AUDFPRINT} match --dbase fpdbase1.pklz precomppkdir/query.afpk
+	${AUDFPRINT} match --dbase fpdbase1.pklz precomppkdir/tests/data/query.afpk
 	rm -rf precomppkdir
 
 precomppkdir: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
 	rm -rf precomppkdir
 	mkdir precomppkdir
-	${AUDFPRINT} precompute --precompute-peaks --precompdir precomppkdir Nine_Lives/*.mp3
-	${AUDFPRINT} precompute --precompute-peaks --precompdir precomppkdir --shifts 4 query.mp3
+	${AUDFPRINT} precompute --precompute-peaks --precompdir precomppkdir tests/data/Nine_Lives/*.mp3
+	${AUDFPRINT} precompute --precompute-peaks --precompdir precomppkdir --shifts 4 tests/data/query.mp3
 
 test_mucore: fpdbase_mu.pklz
-	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 query.mp3
+	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 tests/data/query.mp3
 
 fpdbase_mu.pklz: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
-	${AUDFPRINT} new --dbase fpdbase_mu.pklz --ncores 4 Nine_Lives/0*.mp3
-	${AUDFPRINT} add --dbase fpdbase_mu.pklz --ncores 4 Nine_Lives/1*.mp3
+	${AUDFPRINT} new --dbase fpdbase_mu.pklz --ncores 4 tests/data/Nine_Lives/0*.mp3
+	${AUDFPRINT} add --dbase fpdbase_mu.pklz --ncores 4 tests/data/Nine_Lives/1*.mp3
 
 test_mucore_precomp: precompdir_mu
-	${AUDFPRINT} new --dbase fpdbase_mu0.pklz --ncores 4 precompdir_mu/Nine_Lives/0*
-	${AUDFPRINT} new --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/Nine_Lives/1*
+	${AUDFPRINT} new --dbase fpdbase_mu0.pklz --ncores 4 precompdir_mu/tests/data/Nine_Lives/0*
+	${AUDFPRINT} new --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/tests/data/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase_mu.pklz fpdbase_mu0.pklz
-	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt
+	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt precompdir_mu/tests/data/query.afpt
 
 precompdir_mu: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
 	rm -rf precompdir_mu
 	mkdir precompdir_mu
-	${AUDFPRINT} precompute --ncores 4 --precompdir precompdir_mu Nine_Lives/*.mp3
-	${AUDFPRINT} precompute --ncores 4 --precompdir precompdir_mu --shifts 4 query.mp3 query.mp3 query.mp3 query.mp3 query.mp3 query.mp3
+	${AUDFPRINT} precompute --ncores 4 --precompdir precompdir_mu tests/data/Nine_Lives/*.mp3
+	${AUDFPRINT} precompute --ncores 4 --precompdir precompdir_mu --shifts 4 tests/data/query.mp3 tests/data/query.mp3 tests/data/query.mp3 tests/data/query.mp3 tests/data/query.mp3 tests/data/query.mp3
 
-test_hash_mask: 
-	${AUDFPRINT} new --dbase fpdbase.pklz --hashbits 16 Nine_Lives/*.mp3
-	${AUDFPRINT} match --dbase fpdbase.pklz query.mp3
+test_hash_mask:
+	${AUDFPRINT} new --dbase fpdbase.pklz --hashbits 16 tests/data/Nine_Lives/*.mp3
+	${AUDFPRINT} match --dbase fpdbase.pklz tests/data/query.mp3

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
   -v <val>, --verbose <val>       Verbosity level [default: 1]
   -I, --illustrate                Make a plot showing the match
   -J, --illustrate-hpf            Plot the match, using onset enhancement
+  -O, --json                      Return json object instead of string
   -W <dir>, --wavdir <dir>        Find sound files under this dir [default: ]
   -V <ext>, --wavext <ext>        Extension to add to wav file names [default: ]
   --version                       Report version number
@@ -145,5 +146,3 @@ Scaling
 The fingerprint database records 2^20 (~1M) distinct fingerprints, with (by default) 100 entries for each fingerprint bucket.  When the bucket fills, track entries are dropped at random; since matching depends only on making a minimum number of matches, but no particular match, dropping some of the more popular ones does not prevent matching.  The Matlab version has been successfully used for databases of 100k+ tracks.  Reducing the hash density (`--density`) leads to smaller reference database size, and the capacity to record more reference items before buckets begin to fill; a density of 7.0 works well.
 
 Times (in units of 256 samples, i.e., 23 ms at the default 11kHz sampling rate) are stored in the bottom 14 bits of each database entry, meaning that times larger than 2^14*0.023 = 380 sec, or about 6 mins, are aliased.  If you want to correctly identify time offsets in tracks longer than this, you need to use a larger `--maxtimebits`; e.g. `--maxtimebits 16` increases the time range to 65,536 frames, or about 25 minutes at 11 kHz.  The trade-off is that the remaining bits in each 32 bit entry (i.e., 18 bits for the default 14 bit times) are used to store the track ID.  Thus, by default, the database can only remember 2^18 = 262k tracks; using a larger `--maxtimebits` will reduce this; similarly, you can increase the number of distinct tracks by reducing `--maxtimebits`, which doesn't prevent matching tracks, but progressively reduces discrimination as the number of distinct time slots reduces (and can make the reported time offsets, and time ranges for `--find-time-ranges`, completely wrong for longer tracks).
-
-

--- a/audfprint.py
+++ b/audfprint.py
@@ -171,7 +171,7 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         for filename in filename_iter:
             dur, nhash = analyzer.ingest(hash_tab, filename)
             # report([time.ctime() + " ingesting #" + str(ix) +" : "+ filename + " "+ str(hash_table.track_duration(filename))+"s ..."+str(nhash/dur)+"hashes/s"])
-            report(["{} ingesting # {} : track: {}, duration[sec]: {}, density[hashes/sec]: {} ".format(time.ctime(), str(ix), filename, str(hash_table.track_duration(filename)), str(nhash//dur))])
+            report(["ingesting # {} : track: {}, duration[sec]: {}, density[hashes/sec]: {} ".format(str(ix), filename, str(hash_table.track_duration(filename)), str(nhash//dur))])
             tothashes += nhash
             ix += 1
 

--- a/audfprint.py
+++ b/audfprint.py
@@ -159,8 +159,8 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         for num, filename in enumerate(filename_iter):
             msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
             report(msgs)
-            # msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
-            # report(msgs)
+            msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
+            report(msgs)
 
     elif cmd == 'new' or cmd == 'add':
         # Adding files

--- a/audfprint.py
+++ b/audfprint.py
@@ -158,8 +158,9 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         # Running query, single-core mode
         for num, filename in enumerate(filename_iter):
             msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
-            msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
             report(msgs)
+            # msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
+            # report(msgs)
 
     elif cmd == 'new' or cmd == 'add':
         # Adding files
@@ -167,7 +168,7 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         ix = 0
         for filename in filename_iter:
             report([time.ctime() + " ingesting #" + str(ix) +" : "
-                    + filename + " "+ str(hash_table.track_duration(filename))+"s ..."])
+                    + filename + " "+ str(hash_table.fileduration(filename))+"s ..."])
             dur, nhash = analyzer.ingest(hash_tab, filename)
             tothashes += nhash
             ix += 1

--- a/audfprint.py
+++ b/audfprint.py
@@ -27,12 +27,16 @@ def filename_list_iterator(filelist, wavdir, wavext, listflag):
     """ Iterator to yeild all the filenames, possibly interpreting them
         as list files, prepending wavdir """
     if not listflag:
+        # print(filelist)
         for filename in filelist:
-            yield os.path.join(wavdir, filename + wavext)
+            # print('listflag', os.path.join(wavdir, filename + wavext))
+            yield filename#os.path.join(wavdir, filename + wavext)
     else:
+        # print(filelist)
         for listfilename in filelist:
             with open(listfilename, 'r') as f:
                 for filename in f:
+                    # print('|', os.path.join(wavdir, filename.rstrip('\n') + wavext))
                     yield os.path.join(wavdir, filename.rstrip('\n') + wavext)
 
 

--- a/audfprint.py
+++ b/audfprint.py
@@ -167,9 +167,9 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         tothashes = 0
         ix = 0
         for filename in filename_iter:
-            report([time.ctime() + " ingesting #" + str(ix) +" : "
-                    + filename + " "+ str(hash_table.track_duration(filename))+"s ..."])
             dur, nhash = analyzer.ingest(hash_tab, filename)
+            # report([time.ctime() + " ingesting #" + str(ix) +" : "+ filename + " "+ str(hash_table.track_duration(filename))+"s ..."+str(nhash/dur)+"hashes/s"])
+            report(["{} ingesting # {} : track: {} duration: {}s density: {} hashes/s".format(time.ctime(), str(ix), filename, str(hash_table.track_duration(filename)), str(nhash/dur))])
             tothashes += nhash
             ix += 1
 

--- a/audfprint.py
+++ b/audfprint.py
@@ -483,7 +483,7 @@ def main(argv):
                strip_prefix=args['--wavdir'])
 
     elapsedtime = time.clock() - initticks
-    if analyzer and analyzer.soundfiletotaldur > 0.:
+    if analyzer and analyzer.soundfiletotaldur > 0. and not args['--verbose']:
         print("Processed "
               + "%d files (%.1f s total dur) in %.1f s sec = %.3f x RT" \
               % (analyzer.soundfilecount, analyzer.soundfiletotaldur,

--- a/audfprint.py
+++ b/audfprint.py
@@ -375,7 +375,7 @@ Options:
   -v <val>, --verbose <val>       Verbosity level [default: 1]
   -I, --illustrate                Make a plot showing the match
   -J, --illustrate-hpf            Plot the match, using onset enhancement
-  -O, --json                      Return json object instead of message
+  -O, --json                      Return json object instead of string
   -W <dir>, --wavdir <dir>        Find sound files under this dir [default: ]
   -V <ext>, --wavext <ext>        Extension to add to wav file names [default: ]
   --version                       Report version number

--- a/audfprint.py
+++ b/audfprint.py
@@ -126,7 +126,7 @@ def make_ht_from_list(analyzer, filelist, hashbits, depth, maxtime, pipe=None):
     # Add in the files
     for filename in filelist:
         hashes = analyzer.wavfile2hashes(filename)
-        ht.store(filename, hashes)
+        ht.store(filename, hashes, analyzer.density)
     # Pass back to caller
     if pipe:
         pipe.send(ht)
@@ -168,7 +168,7 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         ix = 0
         for filename in filename_iter:
             report([time.ctime() + " ingesting #" + str(ix) +" : "
-                    + filename + " "+ str(hash_table.fileduration(filename))+"s ..."])
+                    + filename + " "+ str(hash_table.track_duration(filename))+"s ..."])
             dur, nhash = analyzer.ingest(hash_tab, filename)
             tothashes += nhash
             ix += 1

--- a/audfprint.py
+++ b/audfprint.py
@@ -158,6 +158,7 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         # Running query, single-core mode
         for num, filename in enumerate(filename_iter):
             msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
+            msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
             report(msgs)
 
     elif cmd == 'new' or cmd == 'add':
@@ -165,8 +166,8 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         tothashes = 0
         ix = 0
         for filename in filename_iter:
-            report([time.ctime() + " ingesting #" + str(ix) + ": "
-                    + filename + " ..."])
+            report([time.ctime() + " ingesting #" + str(ix) +" : "
+                    + filename + " "+ str(hash_table.track_duration(filename))+"s ..."])
             dur, nhash = analyzer.ingest(hash_tab, filename)
             tothashes += nhash
             ix += 1

--- a/audfprint.py
+++ b/audfprint.py
@@ -157,10 +157,12 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
     elif cmd == 'match':
         # Running query, single-core mode
         for num, filename in enumerate(filename_iter):
-            msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
-            report(msgs)
-            msgs = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
-            report(msgs)
+            if matcher.json:
+                obj = matcher.file_match_to_objs(analyzer, hash_tab, filename, num)
+                print(obj)
+            else:
+                msgs = matcher.file_match_to_msgs(analyzer, hash_tab, filename, num)
+                report(msgs)
 
     elif cmd == 'new' or cmd == 'add':
         # Adding files
@@ -169,7 +171,7 @@ def do_cmd(cmd, analyzer, hash_tab, filename_iter, matcher, outdir, type, report
         for filename in filename_iter:
             dur, nhash = analyzer.ingest(hash_tab, filename)
             # report([time.ctime() + " ingesting #" + str(ix) +" : "+ filename + " "+ str(hash_table.track_duration(filename))+"s ..."+str(nhash/dur)+"hashes/s"])
-            report(["{} ingesting # {} : track: {} duration: {}s density: {} hashes/s".format(time.ctime(), str(ix), filename, str(hash_table.track_duration(filename)), str(nhash/dur))])
+            report(["{} ingesting # {} : track: {}, duration[sec]: {}, density[hashes/sec]: {} ".format(time.ctime(), str(ix), filename, str(hash_table.track_duration(filename)), str(nhash//dur))])
             tothashes += nhash
             ix += 1
 
@@ -303,6 +305,7 @@ def setup_matcher(args):
     matcher.exact_count = args['--exact-count'] | args['--illustrate'] | args['--illustrate-hpf']
     matcher.illustrate = args['--illustrate'] | args['--illustrate-hpf']
     matcher.illustrate_hpf = args['--illustrate-hpf']
+    matcher.json = args['--json']
     matcher.verbose = args['--verbose']
     matcher.find_time_range = args['--find-time-range']
     matcher.time_quantile = float(args['--time-quantile'])
@@ -372,6 +375,7 @@ Options:
   -v <val>, --verbose <val>       Verbosity level [default: 1]
   -I, --illustrate                Make a plot showing the match
   -J, --illustrate-hpf            Plot the match, using onset enhancement
+  -O, --json                      Return json object instead of message
   -W <dir>, --wavdir <dir>        Find sound files under this dir [default: ]
   -V <ext>, --wavext <ext>        Extension to add to wav file names [default: ]
   --version                       Report version number

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -454,7 +454,7 @@ class Analyzer(object):
         #                                                     n_fft=n_fft,
         #                                                     n_hop=n_hop)))
         hashes = self.wavfile2hashes(filename)
-        hashtable.store(filename, hashes)
+        hashtable.store(filename, hashes, self.density)
         # return (len(d)/float(sr), len(hashes))
         # return (np.max(hashes, axis=0)[0]*n_hop/float(sr), len(hashes))
         # soundfiledur is set up in wavfile2hashes, use result here

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -345,7 +345,9 @@ class Analyzer(object):
             list of (time, bin) pairs.  If specified, resample to sr first.
             shifts > 1 causes hashes to be extracted from multiple shifts of
             waveform, to reduce frame effects.  """
-        ext = os.path.splitext(filename)[1]
+
+        _, ext = os.path.splitext(filename)
+
         if ext == PRECOMPPKEXT:
             # short-circuit - precomputed fingerprint file
             peaks = peaks_load(filename)
@@ -421,6 +423,10 @@ class Analyzer(object):
             # Or simply np.unique(query_hashes, axis=0) for numpy >= 1.13
 
         # print("wavfile2hashes: read", len(hashes), "hashes from", filename)
+        # os.
+        filename, ext = os.path.splitext(os.path.basename(filename))
+        with open('tests/csv/'+filename+'.csv', 'w') as f:
+            print('\n'.join(['{}, {}'.format(hash[0], hash[1]) for hash in hashes]), file=f)
         return hashes
 
     # ########## functions to link to actual hash table index database ###### #

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -573,7 +573,7 @@ def glob2hashtable(pattern, density=20.0):
     totdur = 0.0
     tothashes = 0
     for ix, file_ in enumerate(filelist):
-        print(time.ctime(), "ingesting #", ix, ":", file_, track_duration(ix), "...")
+        print(time.ctime(), "ingesting #", ix, ":", file_, track_duration(ix), ht.densityperid[ix], "...")
         dur, nhash = g2h_analyzer.ingest(ht, file_)
         totdur += dur
         tothashes += nhash

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -573,7 +573,7 @@ def glob2hashtable(pattern, density=20.0):
     totdur = 0.0
     tothashes = 0
     for ix, file_ in enumerate(filelist):
-        print(time.ctime(), "ingesting #", ix, ":", file_, "...")
+        print(time.ctime(), "ingesting #", ix, ":", file_, track_duration(ix), "...")
         dur, nhash = g2h_analyzer.ingest(ht, file_)
         totdur += dur
         tothashes += nhash

--- a/audfprint_match.py
+++ b/audfprint_match.py
@@ -456,16 +456,33 @@ class Matcher(object):
         """ Perform a match on a single input file, return list
             of utf-8 json objects
 
-        track: Track (whatever has been fingerprinted) name
-        query_match_length: the length in seconds of how long the match has taken within the query.
-        query_match_start_at: the time in seconds when the match starts to occur in relation to the query time.
-        track_match_start_at: the time in seconds when the match starts to occur in relation to the track time.
-        track_start_at:
-        coverage: Percentage of the query duration against the matched track.
-        fingerprinting_duration: The sum of the time for fingerprinting the query.
-        query_duration: The length in seconds of the query in quest.
-        total_fingerprints_analyzed: The count of all the hits within the database in quest
-        total_tracks_analyzed: How many tracks have been hit through `total_fingerprints_analyzed`
+        track:
+            Name of the Track.
+
+        query_match_length:
+            The length in seconds of how long the measure/match has taken within the query.
+
+        query_match_start_at:
+            The time in seconds when the match starts to occur in relation to the query time.
+
+        track_match_start_at:
+            The time in seconds when the match starts to occur in relation to the track time.
+
+        coverage:
+            Percentage of the query duration in relation to the matched track duration.
+
+        fingerprinting_duration:
+            How long it has take to fingerprint the query.
+
+        query_duration:
+            The length of the query in seconds.
+
+        total_fingerprints_analyzed:
+            The count of all the hits within the database in quest.
+
+        total_tracks_analyzed:
+            How many tracks have been hit through `total_fingerprints_analyzed`
+
         """
 
         o = {}
@@ -473,20 +490,12 @@ class Matcher(object):
         o['query_match_length'] = 0.0
         o['query_match_start_at'] = 0.0
         o['track_match_start_at'] = 0.0
-        o['track_start_at'] = 0.0
         o['coverage'] = 0.0
         o['fingerprinting_duration'] = self.fingerprinting_duration
-        # print(self.fingerprinting_duration)
         rslts, dur, nhash = self.match_file(analyzer, ht, qry, number)
         t_hop = analyzer.n_hop / analyzer.target_sr
-        # print(rslts)
-        # if self.verbose:
-        #     qrymsg = qry + (' %.1f ' % dur) + "sec " + str(nhash) + " raw hashes"
         o['query_duration'] = dur
         o['total_fingerprints_analyzed'] = nhash
-        # else:
-        #     qrymsg = qry
-
         msgrslt = []
 
         if len(rslts) == 0:
@@ -511,20 +520,11 @@ class Matcher(object):
                         o['query_match_start_at'] = min_time * t_hop
                         o['track_match_start_at'] = (min_time + aligntime) * t_hop
                     else:
-                        # msg = "Matched {:s} as {:s} at {:6.1f} s".format(
-                        #         qrymsg, ht.names[tophitid], aligntime * t_hop)
                         o['query_match_start_at'] = aligntime * t_hop
-                        # o['track'] = ht.names[tophitid]
                     o['coverage'] = dur/ht.durationperiod[tophitid]
-                    # msg += (" with {:5d} of {:5d} common hashes"
-                    #         " at rank {:2d}").format(
-                    #         nhashaligned, nhashraw, rank)
                     o['total_tracks_analyzed'] = rank
                     o['confidence'] = nhashaligned/nhashraw
                     o['total_fingerprints_analyzed'] = nhashraw
-                    # msgrslt.append(msg)
-                # else:
-                #     msgrslt.append(qrymsg + "\t" + ht.names[tophitid])
                 if self.illustrate:
                     self.illustrate_match(analyzer, ht, qry)
         track_hashes = ht.retrieve(o['track'])

--- a/audfprint_match.py
+++ b/audfprint_match.py
@@ -517,7 +517,7 @@ class Matcher(object):
                     self.illustrate_match(analyzer, ht, qry)
         track_hashes = ht.retrieve(o['track'])
         print(len(track_hashes))
-        return '', o
+        return o
 
     def illustrate_match(self, analyzer, ht, filename):
         """ Show the query fingerprints and the matching ones

--- a/audfprint_match.py
+++ b/audfprint_match.py
@@ -498,9 +498,10 @@ class Matcher(object):
                         o['querymatchlength'] = (max_time - min_time) * t_hop
                         o['querymatchstartsat'] = min_time * t_hop
                         o['trackmatchstartsat'] = (min_time + aligntime) * t_hop
-                    # else:
+                    else:
                         # msg = "Matched {:s} as {:s} at {:6.1f} s".format(
                         #         qrymsg, ht.names[tophitid], aligntime * t_hop)
+                        o['querymatchstartsat'] = aligntime * t_hop
                         # o['track'] = ht.names[tophitid]
                     o['coverage'] = dur/ht.durationperiod[tophitid]
                     # msg += (" with {:5d} of {:5d} common hashes"
@@ -508,12 +509,14 @@ class Matcher(object):
                     #         nhashaligned, nhashraw, rank)
                     o['totaltracksanalyzed'] = rank
                     o['confidence'] = nhashaligned/nhashraw
+                    o['totalfingerprintsanalyzed'] = nhashraw
                     # msgrslt.append(msg)
                 # else:
                 #     msgrslt.append(qrymsg + "\t" + ht.names[tophitid])
                 if self.illustrate:
                     self.illustrate_match(analyzer, ht, qry)
-
+        track_hashes = ht.retrieve(o['track'])
+        print(len(track_hashes))
         return '', o
 
     def illustrate_match(self, analyzer, ht, filename):
@@ -521,7 +524,7 @@ class Matcher(object):
             plotted over a spectrogram """
         # Make the spectrogram
         # d, sr = librosa.load(filename, sr=analyzer.target_sr)
-        print('filename', filename)
+        print('filename', filename, ht)
         d, sr = audio_read.audio_read(filename, sr=analyzer.target_sr, channels=1)
         sgram = np.abs(librosa.stft(d, n_fft=analyzer.n_fft,
                                     hop_length=analyzer.n_hop,
@@ -542,8 +545,10 @@ class Matcher(object):
                                  cmap='gray_r', vmin=-80.0, vmax=0)
         # Do the match?
         q_hashes = analyzer.wavfile2hashes(filename)
+        # q_hashes = ht.retrieve('tests/data/Nine_Lives/californication.mp3')#o['track'])
         # Run query, get back the hashes for match zero
         results, matchhashes = self.match_hashes(ht, q_hashes, hashesfor=0)
+        print(len(results))
         if self.sort_by_time:
             results = sorted(results, key=lambda x: -x[2])
         # Convert the hashes to landmarks

--- a/audfprint_match.py
+++ b/audfprint_match.py
@@ -50,6 +50,8 @@ import scipy.signal
 import audfprint_analyze  # for localtest and illustrate
 import audio_read
 
+
+import json
 def process_info():
     rss = usrtime = 0
     p = psutil.Process(os.getpid())
@@ -395,9 +397,9 @@ class Matcher(object):
                 numberstring = "#%d" % number
             else:
                 numberstring = ""
-            print(time.ctime(), "Analyzed", numberstring, filename, "of",
-                  ('%.3f' % durd), "s "
-                                   "to", len(q_hashes), "hashes")
+            # print(time.ctime(), "Analyzed", numberstring, filename, "of",
+            #       ('%.3f' % durd), "s "
+            #                        "to", len(q_hashes), "hashes")
         # Run query
         tic = time.clock()
         rslts = self.match_hashes(ht, q_hashes)
@@ -453,7 +455,7 @@ class Matcher(object):
     def file_match_to_objs(self, analyzer, ht, qry, number=None):
         """ Perform a match on a single input file, return list
             of utf-8 json objects """
-        print('query: ', qry)
+
         o = {}
         o['track'] = ''
         o['querymatchlength'] = 0.0
@@ -496,7 +498,6 @@ class Matcher(object):
                         o['querymatchlength'] = (max_time - min_time) * t_hop
                         o['querymatchstartsat'] = min_time * t_hop
                         o['trackmatchstartsat'] = (min_time + aligntime) * t_hop
-                        o['track'] = ht.names[tophitid]
                     # else:
                         # msg = "Matched {:s} as {:s} at {:6.1f} s".format(
                         #         qrymsg, ht.names[tophitid], aligntime * t_hop)
@@ -513,7 +514,7 @@ class Matcher(object):
                 if self.illustrate:
                     self.illustrate_match(analyzer, ht, qry)
 
-        return o
+        return '', o
 
     def illustrate_match(self, analyzer, ht, filename):
         """ Show the query fingerprints and the matching ones
@@ -548,8 +549,9 @@ class Matcher(object):
         # Convert the hashes to landmarks
         lms = audfprint_analyze.hashes2landmarks(q_hashes)
         mlms = audfprint_analyze.hashes2landmarks(matchhashes)
+        print(len(q_hashes))
         print(len(lms))
-        print(len(mlms), len(hits))
+        print(len(mlms))
         # Overplot on the spectrogram
         plt.plot(np.array([[x[0], x[0] + x[3]] for x in lms]).T,
                  np.array([[x[1], x[2]] for x in lms]).T,

--- a/hash_table.py
+++ b/hash_table.py
@@ -423,4 +423,5 @@ class HashTable(object):
             print_fn = print
         for name, count, duration, density in zip(self.names, self.hashesperid, self.durationperiod, self.densityperid):
             if name:
-                print_fn("track: \'{}\' hash_count: {} duration: {}s real_density: {} fingerprinted_density: {}".format(name, str(count), duration, str(float(count)/duration), density))
+                # the purpose of this display is to improve fingreptinting parameter in order to compare across multiple batches
+                print_fn("track: \'{}\', hash_count[units]: {}, duration[s]: {}, real_density: {}, fingerprinted_density: {}".format(name, str(count), duration, str(float(count)/duration), density))

--- a/hash_table.py
+++ b/hash_table.py
@@ -77,6 +77,7 @@ class HashTable(object):
             self.hashbits = hashbits
             self.depth = depth
             self.maxtimebits = _bitsfor(maxtime)
+            self.density=0
             # allocate the big table
             size = 2 ** hashbits
             self.table = np.zeros((size, depth), dtype=np.uint32)
@@ -414,4 +415,4 @@ class HashTable(object):
             print_fn = print
         for name, count, duration in zip(self.names, self.hashesperid, self.durationperiod):
             if name:
-                print_fn("{} ( {} hashes) ( {} s)".format(name, str(count), duration))
+                print_fn("track: \'{}\' hash_count: {} duration: {}s density: {}".format(name, str(count), duration, str(float(count)/duration)))

--- a/hash_table.py
+++ b/hash_table.py
@@ -228,7 +228,6 @@ class HashTable(object):
         nhashes = sum(self.counts)
         # Report the proportion of dropped hashes (overfull table)
         dropped = nhashes - sum(np.minimum(self.depth, self.counts))
-        if args['--verbose']:
         print("Read fprints for", sum(n is not None for n in self.names),
               "files (", nhashes, "hashes) from", name,
               "(%.2f%% dropped)" % (100.0 * dropped / max(1, nhashes)))
@@ -365,12 +364,12 @@ class HashTable(object):
                     self.names[id_] = name
                     self.hashesperid[id_] = 0
                     self.durationperiod[id_] = (name)
-                    self.densityperid[id_] = -1
+                    self.densityperid[id_] = 0
                 except ValueError:
                     self.names.append(name)
                     self.hashesperid = np.append(self.hashesperid, [0])
                     self.durationperiod = np.append(self.durationperiod, [0])
-                    self.densityperid = np.append(self.densityperid, [-1])
+                    self.densityperid = np.append(self.densityperid, [0])
             id_ = self.names.index(name)
         else:
             # we were passed in a numerical id
@@ -423,6 +422,10 @@ class HashTable(object):
         if not print_fn:
             print_fn = print
         for name, count, duration, density in zip(self.names, self.hashesperid, self.durationperiod, self.densityperid):
+            # the purpose of this display is to improve fingreptinting parameter in order to compare across multiple batches
             if name:
-                # the purpose of this display is to improve fingreptinting parameter in order to compare across multiple batches
-                print_fn("track: \'{}\', hash_count[units]: {}, duration[s]: {}, real_density: {}, fingerprinted_density: {}".format(name, str(count), duration, str(float(count)/duration), density))
+                if duration != 0 and duration > 0:
+                    real_density = str(float(count)/duration)
+                    print_fn("track: \'{}\', hash_count[units]: {}, duration[s]: {}, real_density: {}, fingerprinted_density: {}".format(name, str(count), duration, real_density, density))
+                else:
+                    print_fn("track: \'{}\', hash_count[units]: {}, duration[s]: {}, fingerprinted_density: {}".format(name, str(count), duration, density))

--- a/hash_table.py
+++ b/hash_table.py
@@ -228,6 +228,7 @@ class HashTable(object):
         nhashes = sum(self.counts)
         # Report the proportion of dropped hashes (overfull table)
         dropped = nhashes - sum(np.minimum(self.depth, self.counts))
+        if args['--verbose']:
         print("Read fprints for", sum(n is not None for n in self.names),
               "files (", nhashes, "hashes) from", name,
               "(%.2f%% dropped)" % (100.0 * dropped / max(1, nhashes)))

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,0 +1,4 @@
+build-essential
+python3.6 
+python3-pip
+ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ scipy
 docopt
 joblib
 psutil
+
+audioread
+matplotlib
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,6 @@ numpy
 scipy
 docopt
 joblib
-psutil
-
 audioread
 matplotlib
 psutil


### PR DESCRIPTION
The main achievement of this work goes to the `file_match_to_objs` function creation. The function is called through the **-O** option and outputs a json file, example:


### JSON Returns

**python audfprint.py --density 100 -O --skip-existing --find-time-range match --dbase fpdbase.pklz tests/data/query.mp3**
```bash
_Wed Oct 31 00:46:34 2018 Reading hash table fpdbase.pklz
Read fprints for 14 files ( 39724 hashes) from fpdbase.pklz (0.00% dropped)
{'track': 'tests/data/Nine_Lives/05-Full_Circle.mp3', 'query_match_length': 4.481451247165533, 'query_match_start_at': 0.25541950113378686, 'track_match_start_at': 0.25541950113378686, 'coverage': 0.5610389412786497, 'fingerprinting_duration': 0.0, 'query_duration': 5.642448979591837, 'total_fingerprints_analyzed': 54, 'total_tracks_analyzed': 0, 'confidence': 0.9074074074074074}_
```
**WHY?** When using `audfprint` to process queries (stream) coming from multiple _Kafka_ topics, receiving JSON objects has been a significant improvement.

 In order to silent the first two lines, some further decoupling effort would have to be made, for this is located within the `hash_table`.

### DBASE

**python audfprint.py --density 100 --skip-existing new --dbase fpdbase.pklz tests/data/Nine_Lives/*.mp3**
```bash
_ingesting # 0 : track: tests/data/Nine_Lives/01-Nine_Lives.mp3, duration[sec]: 10.057143, density[hashes/sec]: 111.0 
`...`
ingesting # 12 : track: tests/data/Nine_Lives/13-Fallen_Angels.mp3, duration[sec]: 10.057143, density[hashes/sec]: 109.0 
Added 39724 hashes (88.1 hashes/sec)
Saved fprints for 14 files ( 39724 hashes) to fpdbase.pklz (0.00% dropped)_
```
**WHY?** When comparing multiple dbases pragmatically, if one wants to compare the results against the fingerprinting technique, a plausible and minimalist solution would be to keep it stored within the `hash_table` .
**Explanation**: _duration[sec]_ and _density[hashes/sec]_ have so been named so it can be accessed as a key, without any further parsing. I agree that it would look better without the [*], but it may not be obvious.

**python audfprint.py --density 100 --skip-existing --find-time-range list --dbase fpdbase.pklz**
```bash
Wed Oct 31 00:52:38 2018 Reading hash table fpdbase.pklz
Read fprints for 14 files ( 39724 hashes) from fpdbase.pklz (0.00% dropped)
track: 'tests/data/Nine_Lives/01-Nine_Lives.mp3', hash_count[units]: 1114, duration[s]: 10.057143211364746, real_density: 110.76704155322763, fingerprinted_density: 100.0
`...`
track: 'tests/data/Nine_Lives/13-Fallen_Angels.mp3', hash_count[units]: 1095, duration[s]: 10.057143211364746, real_density: 108.87783707431262, fingerprinted_density: 100.0
```
**WHY?**  In case one needs to really get a closer look at the fingerprinting process. As the effective/real fingerprinting density and the desired density `--density` may vary, is seems reasonable to display such information. Not least, the _duration_ may also be an important property to be displayed as the track naming can be automated and hence become humanly hard to understand the outputs.


### CREDITS / REFERENCE
The naming for the JSON keys/properties has been inspired by:
https://github.com/AddictedCS/soundfingerprinting