### PR TITLE
update to use gzip-compressed precompute features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ test_onecore_precomp: precompdir
 	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/Nine_Lives/0*
 	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase1.pklz fpdbase0.pklz
-	${AUDFPRINT} match --dbase fpdbase1.pklz precompdir/query.afpt
+	${AUDFPRINT} match --dbase fpdbase1.pklz precompdir/query.afptz
 
 test_onecore_newmerge: precompdir
 	${AUDFPRINT} new --dbase fpdbase0.pklz precompdir/Nine_Lives/0*
 	${AUDFPRINT} new --dbase fpdbase1.pklz precompdir/Nine_Lives/1*
 	rm -f fpdbase2.pklz
 	${AUDFPRINT} newmerge --dbase fpdbase2.pklz fpdbase0.pklz fpdbase1.pklz
-	${AUDFPRINT} match --dbase fpdbase2.pklz precompdir/query.afpt
+	${AUDFPRINT} match --dbase fpdbase2.pklz precompdir/query.afptz
 
 precompdir: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
 	rm -rf precompdir
@@ -52,7 +52,7 @@ test_onecore_precomppk: precomppkdir
 	${AUDFPRINT} new --dbase fpdbase0.pklz precomppkdir/Nine_Lives/0*
 	${AUDFPRINT} new --dbase fpdbase1.pklz precomppkdir/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase1.pklz fpdbase0.pklz
-	${AUDFPRINT} match --dbase fpdbase1.pklz precomppkdir/query.afpk
+	${AUDFPRINT} match --dbase fpdbase1.pklz precomppkdir/query.afpkz
 	rm -rf precomppkdir
 
 precomppkdir: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
@@ -72,7 +72,7 @@ test_mucore_precomp: precompdir_mu
 	${AUDFPRINT} new --dbase fpdbase_mu0.pklz --ncores 4 precompdir_mu/Nine_Lives/0*
 	${AUDFPRINT} new --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/Nine_Lives/1*
 	${AUDFPRINT} merge --dbase fpdbase_mu.pklz fpdbase_mu0.pklz
-	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt precompdir_mu/query.afpt
+	${AUDFPRINT} match --dbase fpdbase_mu.pklz --ncores 4 precompdir_mu/query.afptz precompdir_mu/query.afptz precompdir_mu/query.afptz precompdir_mu/query.afptz precompdir_mu/query.afptz precompdir_mu/query.afptz precompdir_mu/query.afptz
 
 precompdir_mu: audfprint.py audfprint_analyze.py audfprint_match.py hash_table.py
 	rm -rf precompdir_mu


### PR DESCRIPTION
Attempt to shrink precomputed feature files.  To keep it simple, changing the default mode to include compressed as the desired format, but another command arg could also be added if preferred.

Interestingly, the peak-point only mode did not gain from the small collection of sample files.  This is a quick table of files produced during the `test` run of the main `Makefile`.
```
 60K    gz/precompdir/Nine_Lives
140K    non-zip/precompdir/Nine_Lives
 52K    gz/precomppkdir/Nine_Lives
 52K    non-zip/precomppkdir/Nine_Lives
```

On longer files (9 files with average length of 1h15m) the savings are more apparent (using 11k, density 100, 1 shift).
```
 10M    gz/precompdir/audio/2d
 15M    non-zip/precomp/audio/2d
3.1M    gz/precompk/audio/2d
4.1M    non-zip/precompk/audio/2d
```