### PR TITLE
MS Windows console does not offer expansion

### DIFF
--- a/audfprint.py
+++ b/audfprint.py
@@ -36,7 +36,12 @@ def filename_list_iterator(filelist, wavdir, wavext, listflag):
         as list files, prepending wavdir """
     if not listflag:
         for filename in filelist:
-            yield os.path.join(wavdir, filename + wavext)
+            if os.path.isdir(filename):
+                for root, directories, filenames in os.walk(filename):
+                    for filename in filenames:
+                        yield os.path.join(wavdir, os.path.join(root, filename) + wavext)
+            else:
+                yield os.path.join(wavdir, filename + wavext)
     else:
         for listfilename in filelist:
             with open(listfilename, 'r') as f:


### PR DESCRIPTION
hi,
it's a "quick and dirty" patch that allows you to pass a folder as a parameter.
`audfprint... add/new z:\audios\*` doesn't work on Windows, `audfprint... add/new z:\audios\` will.
`glob.glob` could also be used...
regards.