### PR TITLE
use hash bits more effectively

### DIFF
--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -277,7 +277,7 @@ class Analyzer(object):
         a_dec = (1 - 0.01 * (self.density * np.sqrt(self.n_hop / 352.8) / 35)) ** (1 / OVERSAMP)
         # Take spectrogram
         mywin = np.hanning(self.n_fft + 2)[1:-1]
-        sgram = np.abs(stft.stft(d, n_fft=self.n_fft,
+        sgram = np.abs(stft.stft(d, n_fft=self.n_fft+2,
                                  hop_length=self.n_hop,
                                  window=mywin))
         sgrammax = np.max(sgram)
@@ -289,10 +289,10 @@ class Analyzer(object):
             # zero.  Not good, but let's let it through for now.
             print("find_peaks: Warning: input signal is identically zero.")
         # High-pass filter onset emphasis
-        # [:-1,] discards top bin (nyquist) of sgram so bins fit in 8 bits
+        # [1:-1,] discards bottom (0hz) and top (nyquist) bins of sgram so bins fit in 8 bits
         sgram = np.array([scipy.signal.lfilter([1, -1],
                                                [1, -HPF_POLE ** (1 / OVERSAMP)], s_row)
-                          for s_row in sgram])[:-1, ]
+                          for s_row in sgram])[1:-1, ]
         # Prune to keep only local maxima in spectrum that appear above an online,
         # decaying threshold
         peaks = self._decaying_threshold_fwd_prune(sgram, a_dec)

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -135,8 +135,8 @@ class Analyzer(object):
         # Limit the num of pairs we'll make from each peak (Fanout)
         self.maxpairsperpeak = 3
         # Values controlling peaks2landmarks
-        # +/- 31 bins in freq (LIMITED TO -32..31 IN LANDMARK2HASH)
-        self.targetdf = 31
+        # +/- 32 bins in freq (LIMITED TO -32..31 IN LANDMARK2HASH)
+        self.targetdf = 32
         # min time separation (traditionally 1, upped 2014-08-04)
         self.mindt = 2
         # max lookahead in time (LIMITED TO <64 IN LANDMARK2HASH)
@@ -332,7 +332,8 @@ class Analyzer(object):
                                       min(scols, col + self.targetdt + 1)):
                         if pairsthispeak < self.maxpairsperpeak:
                             for peak2 in peaks_at[col2]:
-                                if abs(peak2 - peak) < self.targetdf:
+                                df = peak2 - peak
+                                if -self.targetdf <= df and df < self.targetdf:
                                     # and abs(peak2-peak) + abs(col2-col) > 2 ):
                                     if pairsthispeak < self.maxpairsperpeak:
                                         # We have a pair!

--- a/audfprint_analyze.py
+++ b/audfprint_analyze.py
@@ -140,7 +140,7 @@ class Analyzer(object):
         # min time separation (traditionally 1, upped 2014-08-04)
         self.mindt = 2
         # max lookahead in time (LIMITED TO <64 IN LANDMARK2HASH)
-        self.targetdt = 63
+        self.targetdt = 65
         # global stores duration of most recently-read soundfile
         self.soundfiledur = 0.0
         # .. and total amount of sound processed
@@ -329,7 +329,7 @@ class Analyzer(object):
                 for peak in peaks_at[col]:
                     pairsthispeak = 0
                     for col2 in range(col + self.mindt,
-                                       min(scols, col + self.targetdt)):
+                                      min(scols, col + self.targetdt + 1)):
                         if pairsthispeak < self.maxpairsperpeak:
                             for peak2 in peaks_at[col2]:
                                 if abs(peak2 - peak) < self.targetdf:
@@ -337,7 +337,7 @@ class Analyzer(object):
                                     if pairsthispeak < self.maxpairsperpeak:
                                         # We have a pair!
                                         landmarks.append((col, peak,
-                                                          peak2, col2 - col))
+                                                          peak2, col2 - col - self.mindt))
                                         pairsthispeak += 1
 
         return landmarks


### PR DESCRIPTION
Audfprint uses most of the possible hash values, but leaves out a few. Fixing this improves recognition rates while storing the same number of hashes, or allows you to reduce the number of hashes stored while keeping acceptable recognition rates.

Of course, this is not backwards-compatible; queries generated with these fixes won't match very well against databases generated without them. I've not made any changes to the hash table code here, so these get saved with the current version number.